### PR TITLE
feat(evaluation): pair-level dedup at (gold, normalized) in load_elig…

### DIFF
--- a/docs/phase_5_sq3_methodology.md
+++ b/docs/phase_5_sq3_methodology.md
@@ -64,11 +64,12 @@ stratification. Rater-model agreement is reported against all five models
 described in §3.3 (KB-BERT [CLS], Swedish SBERT, mE5-large, plus the two
 Qwen-family models in scope at the time of SQ3 execution).
 
-**Eligibility.** Pairs are included if `is_non_response == False` AND
-`is_exact_match == False`. Non-responses (silence, "don't know", etc.) carry
-no semantic content to rate; exact matches receive a definitional score of 1
-and require no human judgment. The eligible-pair count is reported as a
-diagnostic in the executed-protocol log.
+**Eligibility.** A two-stage filter, applied in fixed order: (1) drop rows
+where `is_non_response == True` OR `is_exact_match == True`; (2) deduplicate
+the remaining set at the `(gold, normalized)` level via stable sort and
+keep-first, so the eligibility unit is the unique `(target, response)` pair
+rather than the participant-response row. Both counts (row-level pre-dedup
+and pair-level post-dedup) are reported in `sq3_eligibility_probe.md`.
 
 **Excluded fields.** Rater-facing data does not include `participant_id`,
 `gender`, `age`, `diagnosis`, `mmse`, or `cosine_sim`. The rater sees only the
@@ -468,7 +469,8 @@ The Limitations section will explicitly note:
 
 > Any deviation from this protocol made after rating commences must be
 > recorded here, with date and reason. Empty at time of pre-registration.
-
+"2026-05-XX: Identified upstream normalization bug stripping va from gradskiva. Bug fixed in BNT preprocessor (issue #N); BNT scored-results regenerated. Affects ≤48 pairs in the original eligible pool."
+"2026-05-XX: Added pair-level deduplication to sq3_sampling.py between eligibility filtering and quartile assignment. Eligibility unit changed from row to unique (target, normalized_response) pair. Reproducibility preserved via stable sort + keep-first semantics."
 ---
 
 *Pre-registration date: 2026-05-07.*

--- a/scripts/sq3_eligibility_probe.py
+++ b/scripts/sq3_eligibility_probe.py
@@ -42,14 +42,10 @@ def _df_to_markdown(df: pd.DataFrame) -> str:
 def _build_summary(
     input_path: Path,
     df_full: pd.DataFrame,
-    eligible: pd.DataFrame,
+    counts: dict[str, int],
     cutpoints: tuple[float, float, float],
     contingency: pd.DataFrame,
 ) -> str:
-    n_total = len(df_full)
-    n_eligible = len(eligible)
-    n_non_response = int(df_full["is_non_response"].sum())
-    n_exact_match = int(df_full["is_exact_match"].sum())
     n_both = int((df_full["is_non_response"] & df_full["is_exact_match"]).sum())
     q25, q50, q75 = cutpoints
 
@@ -60,11 +56,21 @@ def _build_summary(
     lines.append("")
     lines.append("## Row counts")
     lines.append("")
-    lines.append(f"- Total rows: {n_total}")
-    lines.append(f"- Eligible rows (post-filter): {n_eligible}")
-    lines.append(f"- Excluded (is_non_response): {n_non_response}")
-    lines.append(f"- Excluded (is_exact_match): {n_exact_match}")
+    lines.append(f"- Total rows: {counts['n_total']}")
+    lines.append(f"- Excluded (is_non_response): {counts['n_non_response']}")
+    lines.append(f"- Excluded (is_exact_match): {counts['n_exact_match']}")
     lines.append(f"- Excluded (both flags True): {n_both}")
+    lines.append(
+        f"- Eligible rows (row-level, pre-dedup): {counts['n_after_filter']}"
+    )
+    lines.append(
+        f"- Duplicates dropped at (gold, normalized): "
+        f"{counts['n_duplicates_dropped']}"
+    )
+    lines.append(
+        f"- Eligible pairs (post-dedup, used for stratification): "
+        f"{counts['n_after_dedup']}"
+    )
     lines.append("")
     lines.append("## Cosine quartile cutpoints (eligibility-filtered)")
     lines.append("")
@@ -98,7 +104,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     df_full = pd.read_csv(args.input)
-    eligible = load_eligible_pairs(args.input)
+    eligible, counts = load_eligible_pairs(args.input, return_counts=True)
     eligible = assign_quartile(eligible)
     cutpoints = compute_quartile_cutpoints(eligible)
 
@@ -120,15 +126,19 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    summary = _build_summary(args.input, df_full, eligible, cutpoints, contingency)
+    summary = _build_summary(args.input, df_full, counts, cutpoints, contingency)
     out_path = args.output_dir / "sq3_eligibility_probe.md"
     out_path.write_text(summary, encoding="utf-8")
 
-    print(f"Total rows: {len(df_full)}")
-    print(f"Eligible rows: {len(eligible)}")
+    print(f"Total rows: {counts['n_total']}")
     print(
-        f"Excluded — non-response: {int(df_full['is_non_response'].sum())}, "
-        f"exact-match: {int(df_full['is_exact_match'].sum())}"
+        f"Excluded — non-response: {counts['n_non_response']}, "
+        f"exact-match: {counts['n_exact_match']}"
+    )
+    print(
+        f"Eligible rows (pre-dedup): {counts['n_after_filter']}; "
+        f"duplicates dropped: {counts['n_duplicates_dropped']}; "
+        f"eligible pairs (post-dedup): {counts['n_after_dedup']}"
     )
     q25, q50, q75 = cutpoints
     print(f"Quartile cutpoints: Q25={q25:.6f}, Q50={q50:.6f}, Q75={q75:.6f}")

--- a/src/thesis_project/evaluation/sq3_sampling.py
+++ b/src/thesis_project/evaluation/sq3_sampling.py
@@ -49,18 +49,42 @@ SENSITIVE_COLUMNS = (
 )
 
 
-def load_eligible_pairs(bnt_results_path: Path) -> pd.DataFrame:
-    """Load the BNT scored-results CSV and return only eligible pairs.
+DEDUP_KEYS = ("gold", "normalized")
 
-    Eligibility:
-        ``is_non_response == False`` AND ``is_exact_match == False``.
 
-    The returned DataFrame is a copy, indexed ``0..n-1``, with all
-    original columns preserved.
+def load_eligible_pairs(
+    bnt_results_path: Path,
+    *,
+    return_counts: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, dict[str, int]]:
+    """Load the BNT scored-results CSV and return eligible (target, response) pairs.
+
+    Two-stage filter (methodology §3):
+
+    1. **Eligibility filter.** Drop rows where ``is_non_response == True``
+       OR ``is_exact_match == True``.
+    2. **Pair-level deduplication.** Stable-sort the remaining rows by
+       ``(gold, normalized, participant_id_or_user)`` and drop duplicates
+       on ``(gold, normalized)``, keeping the first. The eligibility unit
+       is therefore the unique ``(target, response)`` pair, not the
+       participant-response row.
+
+    The composite sort key with the participant column included makes the
+    dedup output invariant under arbitrary permutations of the input row
+    order, so re-running on a regenerated upstream CSV produces the same
+    pair set as long as the underlying data is the same.
+
+    Returns
+    -------
+    DataFrame
+        The deduplicated eligible pair set, reindexed ``0..n-1``.
+    dict
+        (Only when ``return_counts=True``) Pre/post-filter and
+        pre/post-dedup row counts for the eligibility probe summary.
     """
     bnt_results_path = Path(bnt_results_path)
     df = pd.read_csv(bnt_results_path)
-    required = {"is_non_response", "is_exact_match"}
+    required = {"is_non_response", "is_exact_match", *DEDUP_KEYS}
     missing = required - set(df.columns)
     if missing:
         raise ValueError(
@@ -68,7 +92,27 @@ def load_eligible_pairs(bnt_results_path: Path) -> pd.DataFrame:
             f"{sorted(missing)}"
         )
     eligible = df[(~df["is_non_response"]) & (~df["is_exact_match"])].copy()
-    eligible.reset_index(drop=True, inplace=True)
+    n_after_filter = len(eligible)
+
+    sort_keys = list(DEDUP_KEYS)
+    if "participant_id" in eligible.columns:
+        sort_keys.append("participant_id")
+    elif "user" in eligible.columns:
+        sort_keys.append("user")
+    eligible = eligible.sort_values(by=sort_keys, kind="stable")
+    eligible = eligible.drop_duplicates(subset=list(DEDUP_KEYS), keep="first")
+    eligible = eligible.reset_index(drop=True)
+
+    if return_counts:
+        counts = {
+            "n_total": int(len(df)),
+            "n_after_filter": int(n_after_filter),
+            "n_after_dedup": int(len(eligible)),
+            "n_duplicates_dropped": int(n_after_filter - len(eligible)),
+            "n_non_response": int(df["is_non_response"].sum()),
+            "n_exact_match": int(df["is_exact_match"].sum()),
+        }
+        return eligible, counts
     return eligible
 
 

--- a/tests/test_sq3_sampling.py
+++ b/tests/test_sq3_sampling.py
@@ -131,6 +131,77 @@ def test_rater_seed_changes_row_order_but_not_pair_set(tmp_path):
     assert a["pair_id"].tolist() != b["pair_id"].tolist()
 
 
+def test_dedup_at_gold_normalized_is_deterministic(tmp_path):
+    """Same input → same dedup output, regardless of input row order.
+
+    Constructs a small CSV with deliberate duplicates at the
+    ``(gold, normalized)`` level across multiple participants, then
+    asserts the dedup is deterministic and order-invariant.
+    """
+    base = pd.DataFrame(
+        {
+            "participant_id": [
+                "User-2", "User-1", "User-3",  # all share (träd, träd)
+                "User-1", "User-2",            # share (bil, fordon)
+                "User-1",                      # unique (hund, vovve)
+                "User-2",                      # unique (katt, kissemissen)
+            ],
+            "diagnosis": ["HC", "MCI", "AD", "HC", "MCI", "HC", "MCI"],
+            "gold":       ["träd", "träd", "träd", "bil", "bil", "hund", "katt"],
+            "normalized": ["träd", "träd", "träd", "fordon", "fordon", "vovve", "kissemissen"],
+            "is_exact_match":  [False] * 7,
+            "is_non_response": [False] * 7,
+            "cosine_sim": [0.9, 0.9, 0.9, 0.6, 0.6, 0.4, 0.7],
+        }
+    )
+    p1 = tmp_path / "bnt_a.csv"
+    base.to_csv(p1, index=False)
+    out_a = load_eligible_pairs(p1)
+
+    permuted = base.iloc[[3, 0, 5, 6, 1, 4, 2]].reset_index(drop=True)
+    p2 = tmp_path / "bnt_b.csv"
+    permuted.to_csv(p2, index=False)
+    out_b = load_eligible_pairs(p2)
+
+    # 4 unique (gold, normalized) pairs survive.
+    assert len(out_a) == 4
+    assert len(out_b) == 4
+    pairs_a = list(zip(out_a["gold"], out_a["normalized"]))
+    pairs_b = list(zip(out_b["gold"], out_b["normalized"]))
+    assert pairs_a == pairs_b
+
+    # Order-invariance: the kept participant_id within each (gold, normalized)
+    # group is the same regardless of input row order, because the sort
+    # tiebreaker is participant_id.
+    a_kept = dict(zip(pairs_a, out_a["participant_id"]))
+    b_kept = dict(zip(pairs_b, out_b["participant_id"]))
+    assert a_kept == b_kept
+    # For (träd, träd), User-1 should be kept (lexicographically smallest).
+    assert a_kept[("träd", "träd")] == "User-1"
+
+
+def test_load_eligible_pairs_return_counts(tmp_path):
+    base = pd.DataFrame(
+        {
+            "participant_id": ["U1", "U2", "U3", "U4"],
+            "gold":            ["a",  "a",  "b",  "c"],
+            "normalized":      ["x",  "x",  "y",  "z"],
+            "is_exact_match":  [False, False, True,  False],
+            "is_non_response": [False, False, False, False],
+            "cosine_sim":      [0.5, 0.5, 0.9, 0.3],
+        }
+    )
+    p = tmp_path / "bnt.csv"
+    base.to_csv(p, index=False)
+    eligible, counts = load_eligible_pairs(p, return_counts=True)
+    assert counts["n_total"] == 4
+    assert counts["n_exact_match"] == 1
+    assert counts["n_after_filter"] == 3   # row b removed by exact-match
+    assert counts["n_after_dedup"] == 2    # one (a,x) duplicate dropped
+    assert counts["n_duplicates_dropped"] == 1
+    assert len(eligible) == 2
+
+
 def test_training_sample_disjoint_from_live(tmp_path):
     _, df = _synthetic_bnt_csv(tmp_path, n=2400, seed=4)
     eligible = df[~df["is_non_response"] & ~df["is_exact_match"]].reset_index(drop=True)


### PR DESCRIPTION
…ible_pairs

Methodology §3 now specifies a two-stage eligibility filter: (1) drop non-responses and exact matches, (2) deduplicate the remaining set at the (gold, normalized) level via stable sort + keep-first. The eligibility unit becomes the unique (target, response) pair rather than the participant-response row, so participants who agreed on a response no longer inflate the rated-pair pool.

The composite sort key (gold, normalized, participant_id) makes the dedup output invariant under arbitrary input row orders, so re-running on a regenerated upstream CSV (e.g. after the BNT normalization bug fix) produces the same pair set.

load_eligible_pairs gains an opt-in return_counts kwarg surfacing both the pre-dedup row count and post-dedup pair count; sq3_eligibility_probe.py reports both in sq3_eligibility_probe.md as required by §3. New determinism test asserts dedup is order-invariant. Methodology doc records the change in the deviations log.